### PR TITLE
add generics

### DIFF
--- a/src/ccs/cccs.rs
+++ b/src/ccs/cccs.rs
@@ -1,4 +1,5 @@
-use ark_bls12_381::Fr;
+use ark_ec::CurveGroup;
+use ark_ff::PrimeField;
 use ark_std::One;
 use ark_std::Zero;
 use std::ops::Add;
@@ -18,51 +19,52 @@ use crate::util::mle::vec_to_mle;
 /// Witness for the LCCCS & CCCS, containing the w vector, but also the r_w used as randomness in
 /// the Pedersen commitment.
 #[derive(Debug, Clone)]
-pub struct Witness {
-    pub w: Vec<Fr>,
-    pub r_w: Fr, // randomness used in the Pedersen commitment of w
+pub struct Witness<F: PrimeField> {
+    pub w: Vec<F>,
+    pub r_w: F, // randomness used in the Pedersen commitment of w
 }
 
 /// Committed CCS instance
 #[derive(Debug, Clone)]
-pub struct CCCS {
-    pub ccs: CCS,
+pub struct CCCS<C: CurveGroup> {
+    pub ccs: CCS<C>,
 
-    pub C: Commitment,
-    pub x: Vec<Fr>,
+    pub C: Commitment<C>,
+    pub x: Vec<C::ScalarField>,
 }
 
-impl CCS {
+impl<C: CurveGroup> CCS<C> {
     pub fn to_cccs<R: Rng>(
         &self,
         rng: &mut R,
-        pedersen_params: &PedersenParams,
-        z: &[Fr],
-    ) -> (CCCS, Witness) {
-        let w: Vec<Fr> = z[(1 + self.l)..].to_vec();
-        let r_w = Fr::rand(rng);
-        let C = Pedersen::commit(pedersen_params, &w, &r_w);
+        pedersen_params: &PedersenParams<C>,
+        z: &[C::ScalarField],
+    ) -> (CCCS<C>, Witness<C::ScalarField>) {
+        let w: Vec<C::ScalarField> = z[(1 + self.l)..].to_vec();
+        let r_w = C::ScalarField::rand(rng);
+        let C = Pedersen::<C>::commit(pedersen_params, &w, &r_w);
 
         (
-            CCCS {
+            CCCS::<C> {
                 ccs: self.clone(),
                 C,
                 x: z[1..(1 + self.l)].to_vec(),
             },
-            Witness { w, r_w },
+            Witness::<C::ScalarField> { w, r_w },
         )
     }
 }
 
-impl CCCS {
+impl<C: CurveGroup> CCCS<C> {
     /// Computes q(x) = \sum^q c_i * \prod_{j \in S_i} ( \sum_{y \in {0,1}^s'} M_j(x, y) * z(y) )
     /// polynomial over x
-    pub fn compute_q(&self, z: &Vec<Fr>) -> VirtualPolynomial<Fr> {
+    pub fn compute_q(&self, z: &Vec<C::ScalarField>) -> VirtualPolynomial<C::ScalarField> {
         let z_mle = vec_to_mle(self.ccs.s_prime, z);
-        let mut q = VirtualPolynomial::<Fr>::new(self.ccs.s);
+        let mut q = VirtualPolynomial::<C::ScalarField>::new(self.ccs.s);
 
         for i in 0..self.ccs.q {
-            let mut prod: VirtualPolynomial<Fr> = VirtualPolynomial::<Fr>::new(self.ccs.s);
+            let mut prod: VirtualPolynomial<C::ScalarField> =
+                VirtualPolynomial::<C::ScalarField>::new(self.ccs.s);
             for j in self.ccs.S[i].clone() {
                 let M_j = matrix_to_mle(self.ccs.M[j].clone());
 
@@ -73,9 +75,11 @@ impl CCCS {
                     // If this is the first time we are adding something to this virtual polynomial, we need to
                     // explicitly add the products using add_mle_list()
                     // XXX is this true? improve API
-                    prod.add_mle_list([Arc::new(sum_Mz)], Fr::one()).unwrap();
+                    prod.add_mle_list([Arc::new(sum_Mz)], C::ScalarField::one())
+                        .unwrap();
                 } else {
-                    prod.mul_by_mle(Arc::new(sum_Mz), Fr::one()).unwrap();
+                    prod.mul_by_mle(Arc::new(sum_Mz), C::ScalarField::one())
+                        .unwrap();
                 }
             }
             // Multiply by the product by the coefficient c_i
@@ -89,7 +93,11 @@ impl CCCS {
     /// Computes Q(x) = eq(beta, x) * q(x)
     ///               = eq(beta, x) * \sum^q c_i * \prod_{j \in S_i} ( \sum_{y \in {0,1}^s'} M_j(x, y) * z(y) )
     /// polynomial over x
-    pub fn compute_Q(&self, z: &Vec<Fr>, beta: &[Fr]) -> VirtualPolynomial<Fr> {
+    pub fn compute_Q(
+        &self,
+        z: &Vec<C::ScalarField>,
+        beta: &[C::ScalarField],
+    ) -> VirtualPolynomial<C::ScalarField> {
         let q = self.compute_q(z);
         q.build_f_hat(beta).unwrap()
     }
@@ -97,15 +105,16 @@ impl CCCS {
     /// Perform the check of the CCCS instance described at section 4.1
     pub fn check_relation(
         &self,
-        pedersen_params: &PedersenParams,
-        w: &Witness,
+        pedersen_params: &PedersenParams<C>,
+        w: &Witness<C::ScalarField>,
     ) -> Result<(), CCSError> {
         // check that C is the commitment of w. Notice that this is not verifying a Pedersen
         // opening, but checking that the Commmitment comes from committing to the witness.
         assert_eq!(self.C.0, Pedersen::commit(pedersen_params, &w.w, &w.r_w).0);
 
         // check CCCS relation
-        let z: Vec<Fr> = [vec![Fr::one()], self.x.clone(), w.w.to_vec()].concat();
+        let z: Vec<C::ScalarField> =
+            [vec![C::ScalarField::one()], self.x.clone(), w.w.to_vec()].concat();
 
         // A CCCS relation is satisfied if the q(x) multivariate polynomial evaluates to zero in the hypercube
         let q_x = self.compute_q(&z);
@@ -126,16 +135,18 @@ pub mod test {
     use ark_std::test_rng;
     use ark_std::UniformRand;
 
+    use ark_bls12_381::{Fr, G1Projective};
+
     #[test]
     /// Do some sanity checks on q(x). It's a multivariable polynomial and it should evaluate to zero inside the
     /// hypercube, but to not-zero outside the hypercube.
     fn test_compute_q() -> () {
         let mut rng = test_rng();
 
-        let ccs = get_test_ccs();
+        let ccs = get_test_ccs::<G1Projective>();
         let z = get_test_z(3);
 
-        let pedersen_params = Pedersen::new_params(&mut rng, ccs.n - ccs.l - 1);
+        let pedersen_params = Pedersen::<G1Projective>::new_params(&mut rng, ccs.n - ccs.l - 1);
         let (cccs, _) = ccs.to_cccs(&mut rng, &pedersen_params, &z);
         let q = cccs.compute_q(&z);
 
@@ -157,7 +168,7 @@ pub mod test {
         let z = get_test_z(3);
         ccs.check_relation(&z).unwrap();
 
-        let pedersen_params = Pedersen::new_params(&mut rng, ccs.n - ccs.l - 1);
+        let pedersen_params = Pedersen::<G1Projective>::new_params(&mut rng, ccs.n - ccs.l - 1);
         let (cccs, _) = ccs.to_cccs(&mut rng, &pedersen_params, &z);
 
         let beta: Vec<Fr> = (0..ccs.s).map(|_| Fr::rand(&mut rng)).collect();

--- a/src/ccs/ccs.rs
+++ b/src/ccs/ccs.rs
@@ -1,6 +1,5 @@
-use ark_bls12_381::Fr;
+use ark_ec::CurveGroup;
 use ark_std::{log2, One, Zero};
-
 use std::ops::Neg;
 
 // XXX use thiserror everywhere? espresso doesnt use it...
@@ -9,7 +8,7 @@ use thiserror::Error;
 use crate::util::vec::*;
 
 /// A sparse representation of constraint matrices.
-pub type Matrix = Vec<Vec<Fr>>;
+pub type Matrix<F> = Vec<Vec<F>>;
 
 #[derive(Error, Debug)]
 pub enum CCSError {
@@ -19,7 +18,7 @@ pub enum CCSError {
 
 /// A CCS structure
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct CCS {
+pub struct CCS<C: CurveGroup> {
     // m: number of columns in M_i (such that M_i \in F^{m, n})
     pub m: usize,
     // n = |z|, number of rows in M_i
@@ -37,26 +36,27 @@ pub struct CCS {
     // s_prime = log(n)
     pub s_prime: usize,
 
-    pub M: Vec<Matrix>,
+    pub M: Vec<Matrix<C::ScalarField>>,
     pub S: Vec<Vec<usize>>,
-    pub c: Vec<Fr>,
+    pub c: Vec<C::ScalarField>,
 }
 
-impl CCS {
+impl<C: CurveGroup> CCS<C> {
     /// Check that a CCS structure is satisfied by a z vector.
     /// This works with matrices. It doesn't do any polynomial stuff
     /// Only for testing
-    pub fn check_relation(&self, z: &[Fr]) -> Result<(), CCSError> {
-        let mut result = vec![Fr::zero(); self.m];
+    pub fn check_relation(&self, z: &[C::ScalarField]) -> Result<(), CCSError> {
+        let mut result = vec![C::ScalarField::zero(); self.m];
 
         for i in 0..self.q {
             // XXX This can be done more neatly with a .fold() or .reduce()
 
             // Extract the needed M_j matrices out of S_i
-            let vec_M_j: Vec<&Matrix> = self.S[i].iter().map(|j| &self.M[*j]).collect();
+            let vec_M_j: Vec<&Matrix<C::ScalarField>> =
+                self.S[i].iter().map(|j| &self.M[*j]).collect();
 
             // Complete the hadamard chain
-            let mut hadamard_result = vec![Fr::one(); self.m];
+            let mut hadamard_result = vec![C::ScalarField::one(); self.m];
             for M_j in vec_M_j.into_iter() {
                 hadamard_result = hadamard(&hadamard_result, &mat_vec_mul(M_j, z));
             }
@@ -79,7 +79,12 @@ impl CCS {
     }
 
     /// Converts the R1CS structure to the CCS structure
-    fn from_r1cs(A: Vec<Vec<Fr>>, B: Vec<Vec<Fr>>, C: Vec<Vec<Fr>>, io_len: usize) -> Self {
+    fn from_r1cs(
+        A: Vec<Vec<C::ScalarField>>,
+        B: Vec<Vec<C::ScalarField>>,
+        C: Vec<Vec<C::ScalarField>>,
+        io_len: usize,
+    ) -> Self {
         let m = A.len();
         let n = A[0].len();
         Self {
@@ -93,7 +98,7 @@ impl CCS {
             d: 2,
 
             S: vec![vec![0, 1], vec![2]],
-            c: vec![Fr::one(), Fr::one().neg()],
+            c: vec![C::ScalarField::one(), C::ScalarField::one().neg()],
             M: vec![A, B, C],
         }
     }
@@ -102,7 +107,7 @@ impl CCS {
 /// Return a CCS circuit that implements the Vitalik `x^3 + x + 5 == 35` (from
 /// https://www.vitalik.ca/general/2016/12/10/qap.html )
 #[cfg(test)]
-pub fn get_test_ccs() -> CCS {
+pub fn get_test_ccs<C: CurveGroup>() -> CCS<C> {
     let A = to_F_matrix(vec![
         vec![0, 1, 0, 0, 0, 0],
         vec![0, 0, 0, 1, 0, 0],
@@ -124,9 +129,11 @@ pub fn get_test_ccs() -> CCS {
     CCS::from_r1cs(A, B, C, 1)
 }
 
+#[cfg(test)]
+use ark_ff::PrimeField;
 /// Computes the z vector for the given input for Vitalik's equation.
 #[cfg(test)]
-pub fn get_test_z(input: usize) -> Vec<Fr> {
+pub fn get_test_z<F: PrimeField>(input: usize) -> Vec<F> {
     // z = (1, io, w)
     to_F_vec(vec![
         1,
@@ -141,11 +148,12 @@ pub fn get_test_z(input: usize) -> Vec<Fr> {
 #[cfg(test)]
 pub mod test {
     use super::*;
+    use ark_bls12_381::G1Projective;
 
     #[test]
     /// Test that a basic CCS relation can be satisfied
     fn test_ccs_relation() -> () {
-        let ccs = get_test_ccs();
+        let ccs = get_test_ccs::<G1Projective>();
         let z = get_test_z(3);
 
         ccs.check_relation(&z).unwrap();

--- a/src/util/hypercube.rs
+++ b/src/util/hypercube.rs
@@ -2,21 +2,25 @@
 
 /// XXX maybe rename it to domain to resemble the univariate case
 use crate::espresso::virtual_polynomial::bit_decompose;
-use ark_bls12_381::Fr;
+use ark_ff::PrimeField;
+
+use std::marker::PhantomData;
 
 /// A boolean hypercube that returns its points as an iterator
 /// If you iterate on it for 3 variables you will get points in little-endian order:
 /// 000 -> 100 -> 010 -> 110 -> 001 -> 101 -> 011 -> 111
 #[derive(Debug)]
-pub struct BooleanHypercube {
+pub struct BooleanHypercube<F: PrimeField> {
+    _f: PhantomData<F>,
     n_vars: usize,
     current: u64,
     max: u64,
 }
 
-impl BooleanHypercube {
+impl<F: PrimeField> BooleanHypercube<F> {
     pub fn new(n_vars: usize) -> Self {
-        BooleanHypercube {
+        BooleanHypercube::<F> {
+            _f: PhantomData::<F>,
             n_vars,
             current: 0,
             max: 2_u32.pow(n_vars as u32) as u64,
@@ -24,19 +28,19 @@ impl BooleanHypercube {
     }
 
     /// returns the entry at given i (which is the little-endian bit representation of i)
-    pub fn at_i(&self, i: usize) -> Vec<Fr> {
+    pub fn at_i(&self, i: usize) -> Vec<F> {
         assert!(i < self.max as usize);
         let bits = bit_decompose((i) as u64, self.n_vars);
-        bits.iter().map(|&x| Fr::from(x)).collect()
+        bits.iter().map(|&x| F::from(x)).collect()
     }
 }
 
-impl Iterator for BooleanHypercube {
-    type Item = Vec<Fr>;
+impl<F: PrimeField> Iterator for BooleanHypercube<F> {
+    type Item = Vec<F>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let bits = bit_decompose(self.current, self.n_vars);
-        let result: Vec<Fr> = bits.iter().map(|&x| Fr::from(x)).collect();
+        let result: Vec<F> = bits.iter().map(|&x| F::from(x)).collect();
         self.current += 1;
 
         if self.current > self.max {
@@ -50,10 +54,11 @@ impl Iterator for BooleanHypercube {
 #[cfg(test)]
 mod test {
     use super::*;
+    use ark_bls12_381::Fr;
 
     #[test]
     fn test_hypercube() -> () {
-        for (i, point) in BooleanHypercube::new(3).enumerate() {
+        for (i, point) in BooleanHypercube::<Fr>::new(3).enumerate() {
             println!("#{}: {:?}", i, point);
             // XXX this is not a test...
         }

--- a/src/util/vec.rs
+++ b/src/util/vec.rs
@@ -2,9 +2,8 @@
 ///
 /// Stole a bunch of code from Alex in https://github.com/alex-ozdemir/bulletproofs
 /// and wrote some lame tests for it
-use ark_bls12_381::Fr;
+use ark_ff::PrimeField;
 use ark_std::cfg_iter;
-use ark_std::Zero;
 
 use rayon::iter::IndexedParallelIterator;
 use rayon::iter::IntoParallelRefIterator;
@@ -13,15 +12,15 @@ use rayon::iter::ParallelIterator;
 use crate::ccs::ccs::Matrix; // XXX abstraction leak
 
 /// Hadamard product between two vectors
-pub fn hadamard(a: &Vec<Fr>, b: &Vec<Fr>) -> Vec<Fr> {
+pub fn hadamard<F: PrimeField>(a: &Vec<F>, b: &Vec<F>) -> Vec<F> {
     cfg_iter!(a).zip(b).map(|(a, b)| *a * b).collect()
 }
 
 // Multiply matrix by vector
-pub fn mat_vec_mul(mat: &Matrix, vec: &[Fr]) -> Vec<Fr> {
+pub fn mat_vec_mul<F: PrimeField>(mat: &Matrix<F>, vec: &[F]) -> Vec<F> {
     // matrices are lists of rows
     // rows are (value, idx) pairs
-    let mut result = vec![Fr::zero(); mat.len()];
+    let mut result = vec![F::zero(); mat.len()];
     for (r, mat_row) in mat.iter().enumerate() {
         for (c, mat_val) in mat_row.iter().enumerate() {
             assert!(c < vec.len());
@@ -32,40 +31,40 @@ pub fn mat_vec_mul(mat: &Matrix, vec: &[Fr]) -> Vec<Fr> {
 }
 
 // Multiply vector by scalar
-pub fn vec_scalar_mul(vec: &[Fr], c: &Fr) -> Vec<Fr> {
-    let mut result = vec![Fr::zero(); vec.len()];
+pub fn vec_scalar_mul<F: PrimeField>(vec: &[F], c: &F) -> Vec<F> {
+    let mut result = vec![F::zero(); vec.len()];
     for (i, a) in vec.iter().enumerate() {
-        result[i] = a * c;
+        result[i] = *a * c;
     }
     result
 }
 
 // Add two vectors
-pub fn vec_add(vec_a: &[Fr], vec_b: &[Fr]) -> Vec<Fr> {
+pub fn vec_add<F: PrimeField>(vec_a: &[F], vec_b: &[F]) -> Vec<F> {
     assert_eq!(vec_a.len(), vec_b.len());
 
-    let mut result = vec![Fr::zero(); vec_a.len()];
+    let mut result = vec![F::zero(); vec_a.len()];
     for i in 0..vec_a.len() {
         result[i] = vec_a[i] + vec_b[i];
     }
     result
 }
 
-pub fn to_F_matrix(M: Vec<Vec<usize>>) -> Vec<Vec<Fr>> {
-    let mut R: Vec<Vec<Fr>> = vec![Vec::new(); M.len()];
+pub fn to_F_matrix<F: PrimeField>(M: Vec<Vec<usize>>) -> Vec<Vec<F>> {
+    let mut R: Vec<Vec<F>> = vec![Vec::new(); M.len()];
     for i in 0..M.len() {
-        R[i] = vec![Fr::zero(); M[i].len()];
+        R[i] = vec![F::zero(); M[i].len()];
         for j in 0..M[i].len() {
-            R[i][j] = Fr::from(M[i][j] as u64);
+            R[i][j] = F::from(M[i][j] as u64);
         }
     }
     R
 }
 
-pub fn to_F_vec(z: Vec<usize>) -> Vec<Fr> {
-    let mut r: Vec<Fr> = vec![Fr::zero(); z.len()];
+pub fn to_F_vec<F: PrimeField>(z: Vec<usize>) -> Vec<F> {
+    let mut r: Vec<F> = vec![F::zero(); z.len()];
     for i in 0..z.len() {
-        r[i] = Fr::from(z[i] as u64);
+        r[i] = F::from(z[i] as u64);
     }
     r
 }
@@ -73,6 +72,7 @@ pub fn to_F_vec(z: Vec<usize>) -> Vec<Fr> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use ark_bls12_381::Fr;
 
     #[test]
     fn test_hadamard() -> () {


### PR DESCRIPTION
Doing this through a branch & PR so we can review it better and evaluate before deciding if to use it or not.

Some notes:
I thought that is comfortable to enjoy `F` in the CCS impl instead of `C::ScalarField` which is longer. The problem is that later for LCCCS & CCCS, due the Commitment, they need to work over the curve group `C: CurveGroup`, thus all structs & methods that until now were working on `Fr` and that now would be `F`, it will need to be `C::ScalarField`.
But in the current version, `CCS` is 'protected' from this and can keep enjoying working with `F` (instead of `C::ScalarField`).
This comes at the 'cost' of in the methods `to_lcccs` and `to_cccs` we need to 'convert' the `CCS<F>` into `CCS<C::ScalarField>`. Is not a big deal, but it would be more clean if CCS was already on `C` instead of `F`, even that CCS does not need any curve group stuff except for `C::ScalarField`.

Let me know what do you think, I'm currently slightly inclined in favour of migrating CCS to `C` also, as the code involved is few stuff compared to the current version of 'hacking' the `CCS<F>` to `CCS<C::ScalarField>`, but for the moment I left it in that way so we can evaluate it better.

_

For the rest, I think that the verbosity added because of generics is still manageable for the benefit of having the multifolding implementation with generics (as the rest of arkworks & hyperplonk libs).